### PR TITLE
Remove more unneeded packages

### DIFF
--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -15,13 +15,13 @@ video_pkgs="mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon vulkan-intel \
 	libva-intel-driver lib32-libva-intel-driver intel-media-driver lib32-mesa-utils"
 
 wine_pkgs="giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap \
-	gnutls lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal \
-	v4l-utils lib32-v4l-utils libpulse lib32-libpulse alsa-plugins \
-	lib32-alsa-plugins alsa-lib lib32-alsa-lib libjpeg-turbo \
+	gnutls lib32-gnutls mpg123 lib32-mpg123 \
+	v4l-utils lib32-v4l-utils libpulse lib32-libpulse \
+	alsa-lib lib32-alsa-lib libjpeg-turbo \
 	lib32-libjpeg-turbo libxcomposite lib32-libxcomposite libxinerama \
-	lib32-libxinerama libxslt lib32-libxslt libva lib32-libva gtk3 \
-	lib32-gtk3 vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2 \
-	vkd3d lib32-vkd3d libgphoto2 ffmpeg gst-plugins-good gst-plugins-bad \
+	libxslt lib32-libxslt libva lib32-libva \
+	vulkan-icd-loader lib32-vulkan-icd-loader sdl2 lib32-sdl2 \
+	vkd3d lib32-vkd3d libgphoto2 ffmpeg gst-plugins-good \
 	gst-plugins-ugly gst-plugins-base lib32-gst-plugins-good \
 	lib32-gst-plugins-base gst-libav wget gst-plugin-pipewire"
 


### PR DESCRIPTION
gtk3 gets reinstalled by zenity-gtk3, don't worry that I removed it there. 

I tested the appimage launching a steam native game (cs2) and a proton game (BeamNG), it works. I also tested zenity just in case.