### PR TITLE
Allow appimages to run in conty

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         APP=steam
         wget -q https://raw.githubusercontent.com/ivan-hc/Conty/master/create-conty.sh
         wget -q https://raw.githubusercontent.com/ivan-hc/Conty/master/conty-start.sh
-        wget -q https://github.com/ivan-hc/Conty/releases/download/utils/utils_dwarfs.tar.gz
+        wget -q https://github.com/Samueru-sama/Conty/releases/download/utils/utils_dwarfs.tar.gz
         chmod +x create-arch-bootstrap.sh create-conty.sh "$APP"-conty-builder.sh
         sudo ./create-arch-bootstrap.sh && ./create-conty.sh
         mkdir -p tmp/"$APP".AppDir

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
         wget -q https://raw.githubusercontent.com/ivan-hc/Conty/master/conty-start.sh
         wget -q https://github.com/Samueru-sama/Conty/releases/download/utils/utils_dwarfs.tar.gz
         chmod +x create-arch-bootstrap.sh create-conty.sh "$APP"-conty-builder.sh
+        tar fx ./utils_dwarfs.tar.gz
         sudo ./create-arch-bootstrap.sh && ./create-conty.sh
         mkdir -p tmp/"$APP".AppDir
         mv ./conty.sh tmp/"$APP".AppDir/ || exit 1

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -422,10 +422,9 @@ unmount_chroot
 rm -f "${bootstrap}"/var/cache/pacman/pkg/*
 
 # Use the patched bwrap to allow launching AppImages from conty
-wget -q https://github.com/Samueru-sama/Conty/releases/download/utils/utils_dwarfs.tar.gz
-tar fx ./utils_dwarfs.tar.gz
-cp ./utils/bwrap "${bootstrap}"/usr/bin && rm -rf ./utils ./utils_dwarfs.tar.gz
-chmod +x "${bootstrap}"/usr/bin/bwrap
+echo "Using patched bubblewrap..."
+cp ./utils/bwrap "${bootstrap}"/usr/bin || exit 1
+chmod +x "${bootstrap}"/usr/bin/bwrap || exit 1
 
 # Create some empty files and directories
 # This is needed for bubblewrap to be able to bind real files/dirs to them

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -421,6 +421,12 @@ unmount_chroot
 # Clear pacman package cache
 rm -f "${bootstrap}"/var/cache/pacman/pkg/*
 
+# Use the patched bwrap to allow launching AppImages from conty
+wget -q https://github.com/Samueru-sama/Conty/releases/download/utils/utils_dwarfs.tar.gz
+tar fx ./utils_dwarfs.tar.gz
+cp ./utils/bwrap "${bootstrap}"/usr/bin && rm -rf ./utils ./utils_dwarfs.tar.gz
+chmod +x "${bootstrap}"/usr/bin/bwrap
+
 # Create some empty files and directories
 # This is needed for bubblewrap to be able to bind real files/dirs to them
 # later in the conty-start.sh script

--- a/steam-conty-builder.sh
+++ b/steam-conty-builder.sh
@@ -315,7 +315,7 @@ cat >> ./AppRun << 'EOF'
 #!/bin/sh
 HERE="$(dirname "$(readlink -f "${0}")")"
 export UNION_PRELOAD="${HERE}"
-"${HERE}"/conty.sh --bind-try /usr/share/fonts /usr/share/fonts -- steam-screensaver-fix-runtime "$@"
+"${HERE}"/conty.sh --cap-add CAP_SYS_ADMIN --bind-try /usr/share/fonts /usr/share/fonts -- steam-screensaver-fix-runtime "$@"
 EOF
 chmod a+x ./AppRun
 


### PR DESCRIPTION
This fixes the problem that bubblewrap doesn't normally let you run appimages due to fusermount being a SUID binary. 

The fix works by passing the `--cap-add CAP_SYS_ADMIN` flag to bubblewrap and also by patching bubblewrap to allow nested bubblewraps with capabilities. Because otherwise Steam would not work lol. 

Right now the patched utils_dwarfs is being pulled from [my fork of conty](https://github.com/Samueru-sama/Conty/releases) but I highly recommend that you get that in your own conty and also in junest and all other appimages that use bubblewrap, you can see [the patch here](https://github.com/ivan-hc/Conty/compare/master...Samueru-sama:Conty:master) 

