### PR TITLE
Patch conty-start to use dwarfs instead of dwarfs3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
         wget -q https://raw.githubusercontent.com/ivan-hc/Conty/master/conty-start.sh
         wget -q https://github.com/Samueru-sama/Conty/releases/download/utils/utils_dwarfs.tar.gz
         chmod +x create-arch-bootstrap.sh create-conty.sh "$APP"-conty-builder.sh
+        sed -i 's|dwarfs"${fuse_version}"|dwarfs|g' ./conty-start.sh
         tar fx ./utils_dwarfs.tar.gz
         sudo ./create-arch-bootstrap.sh && ./create-conty.sh
         mkdir -p tmp/"$APP".AppDir


### PR DESCRIPTION
It is still dwarfs 3, just that the static dwarfs-tools binary does not recognize dwarfs3 as an option. 

I switched to a [mostly static utils](https://github.com/Samueru-sama/Conty/commit/d11307c23df2d4ec2cd3a534b2adf257b4f747cb), so **this is needed for the steam appimage to work**.

This also cut down the build time of the utils from 33 minutes to 3 minutes, and it will likely be less than a minute if I can get a fully static utils to work.

This makes the appimage 441 MiB, it would be 439 MiB if I make it fully static which it isn't right now.

