### PR TITLE
Remove python caches

### DIFF
--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -410,6 +410,7 @@ rm -f "${bootstrap}"/usr/bin/pacman*
 find "${bootstrap}"/usr/lib "${bootstrap}"/usr/lib32 -type f -regex '.*\.a' -exec rm -f {} \;
 find "${bootstrap}"/usr -type f -regex '.*\.so.*' -exec strip --strip-debug {} \;
 find "${bootstrap}"/usr/bin -type f ! -regex '.*\.so.*' -exec strip --strip-unneeded {} \;
+find "${bootstrap}"/usr/lib -type f -regex '.*\.pyc' -exec rm -f {} \;
 
 # Check if the command we are interested in has been installed
 if ! run_in_chroot which steam-screensaver-fix-runtime; then echo "Command not found, exiting." && exit 1; fi


### PR DESCRIPTION
Note this is something you have to be careful if you want to try on other appimages. 

Removing the python caches can lead to big startup delays of python apps, however steam provides the steam runtime with its own python, in this case the python used here is used mostly for mangohud and I did some benchmarks and there wasn't anything significant. 

This brings the size down to 430 MiB.