### PR TITLE
remove mangoplot

### DIFF
--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -369,7 +369,7 @@ run_in_chroot rm -f "${bootstrap}"/etc/locale.conf
 run_in_chroot sed -i 's/LANG=${LANG:-C}/LANG=$LANG/g' /etc/profile.d/locale.sh
 
 # Remove bloatwares
-run_in_chroot pacman --noconfirm -Rsndd gcc yay systemd git autoconf automake
+run_in_chroot pacman --noconfirm -Rsndd gcc yay systemd git autoconf automake python-matplotlib python-numpy python-contourpy
 run_in_chroot pacman -Qdtq | run_in_chroot pacman --noconfirm -Rsn -
 
 # Generate a list of installed packages

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -403,6 +403,7 @@ rm -f "${bootstrap}"/usr/bin/yay
 rm -f "${bootstrap}"/usr/bin/git*
 rm -f "${bootstrap}"/usr/bin/systemd*
 rm -f "${bootstrap}"/usr/bin/pacman*
+rm -f "${bootstrap}"/usr/bin/mangoplot
 find "${bootstrap}"/usr/lib "${bootstrap}"/usr/lib32 -type f -regex '.*\.a' -exec rm -f {} \;
 find "${bootstrap}"/usr -type f -regex '.*\.so.*' -exec strip --strip-debug {} \;
 find "${bootstrap}"/usr/bin -type f ! -regex '.*\.so.*' -exec strip --strip-unneeded {} \;


### PR DESCRIPTION
Turns out mangohud has that +100 MiB python dependency because it ships a python script called [mangoplot](https://hiddensymmetries.github.io/mango/plotting.html), which is used to make graph out of recorded mangohud benchmarks. 

This isn't needed in the appimage, mangohud doesn't need to those python deps to work and also I don't think the user could use the built in mangoplot in the appimage to make a graph out of the recorded benchmark since mangoplot would not show in PATH, this has to come from the host instead. 

This now makes the appimage 390 MiB and significantly smaller than installing Steam as a native package.

![image](https://github.com/user-attachments/assets/e346da5c-170d-4fb2-87df-940f305a7295)
