### PR TITLE
switch making appimage with runimage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: build
       run: |
-        sudo apt install zsync
+        sudo apt install zsync llvm
         chmod +x ./steam-runimage.sh && ./steam-runimage.sh
         mkdir -p ./dist
         mv *.AppImage* dist/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,16 +16,10 @@ jobs:
 
     - name: build
       run: |
-        sudo apt install desktop-file-utils
-        APP=steam
-        wget -q https://github.com/ivan-hc/Steam-appimage/releases/download/utils/utils_dwarfs.tar.gz
-        chmod +x create-arch-bootstrap.sh create-conty.sh "$APP"-conty-builder.sh
-        sudo ./create-arch-bootstrap.sh && ./create-conty.sh
-        mkdir -p tmp/"$APP".AppDir
-        mv ./conty.sh tmp/"$APP".AppDir/ || exit 1
-        ./"$APP"-conty-builder.sh
-        mkdir dist
-        mv *AppImage* dist/
+        sudo apt install zsync
+        chmod +x ./steam-runimage.sh && ./steam-runimage.sh
+        mkdir -p ./dist
+        mv *.AppImage* dist/
 
     - name: Check version file
       run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Unofficial AppImage of Steam built on top of "[Conty](https://github.com/Kron4ek/Conty)", the portable Arch Linux container that runs everywhere.
+Unofficial AppImage of Steam built on top of "[RunImage](https://github.com/VHSgunzo/runimage)", the portable single-file Linux container in unprivileged user namespaces
 
-This includes 32bit libraries needed to run Steam, also it downloads and installs in ~/.local/share/Conty a portable version of Nvidia drivers if needed.
+This includes 32bit libraries needed to run Steam, **it will also use the proprietary nvidia driver from the host**.
 
 ---------------------------------
 
@@ -13,6 +13,7 @@ This includes 32bit libraries needed to run Steam, also it downloads and install
 - "sudo" is not required, no need enable 32 bit repo, no need to install flatpak or snap, **it should even run on musl distros.**
 - Can use a [portable home](https://docs.appimage.org/user-guide/portable-mode.html), so you can avoid all the [mess that Steam leaves in $HOME](https://github.com/ValveSoftware/steam-for-linux/issues/1890) and no need to settle with a hardcoded `~/.var` or `~/snap` either.
 - Uses a patched bubblewrap that [allows](https://github.com/flathub/com.valvesoftware.Steam/issues/770) launching AppImages from Steam.
+- Will use the nvidia driver from the host instead of downloading one, note that for this to happen you also need the 32bit nvidia driver, otherwise runimage will fallback to download it. 
 
 ---------------------------------
 
@@ -23,7 +24,7 @@ This includes 32bit libraries needed to run Steam, also it downloads and install
 ```
 chmod a+x ./*.AppImage
 ```
-3. Run it, do this the first time from terminal, since the internal "Conty" script may detect if you need Nvidia drivers for your GPU
+3. Run it or simply double click on it. 
 ```
 ./*.AppImage
 ```
@@ -35,52 +36,9 @@ This AppImage does NOT require libfuse2, being it a new generation one.
 
 ### How to build it
 
-Currently, the AppImage I produced contains the following structure:
-```
-|---- AppRun
-|---- steam.desktop
-|---- steam.png
-|---- conty.sh
-```
-1. The AppRun is the core script of the AppImage
-2. The .desktop file of Steam
-3. The icon of Steam
-4. The Arch Linux container named "conty.sh", it contains Steam.
-
-Points 1, 2 and 3 are the essential elements of any AppImage.
-
-The script "conty.sh" (4) is the big one among the elements of this AppImage.
-
-This is what each file of my workflow is ment for:
-1. [create-arch-bootstrap.sh](https://github.com/ivan-hc/Steam-appimage/blob/main/create-arch-bootstrap.sh) creates an Arch Linux chroot, where Steam is installed. This is the first script to be used ("root" required);
-2. [create-conty.sh](https://github.com/ivan-hc/Conty/blob/master/create-conty.sh) is the second script used in this process, it converts the Arch Linux chroot created by "create-arch-bootstrap.sh" into a big script named "conty.sh", that includes "conty-start.sh";
-3. [conty-start.sh](https://github.com/ivan-hc/Conty/blob/master/conty-start.sh) is the script responsible of startup inizialization processes to made Conty work. It includes a function that detects the version of the Nvidia drivers needed, if they are needed, the script downloads and installs them in ~/.local/share/Conty. Also it is responsible of full integration of Conty with the host system, using "bubblewrap;
-4. [utils_dwarfs.tar.gz](https://github.com/ivan-hc/Conty/releases/download/utils/utils_dwarfs.tar.gz) contains "dwarfs", a set of tools similar to squashfs to compress filesystems, and it is needed to compress "conty.sh" as much as possible;
-5. [steam-conty-builder.sh](https://github.com/ivan-hc/Steam-appimage/blob/main/steam-conty-builder.sh) is a script i wrote to pundle "conty.sh" near the AppRun, the .desktop file and the icon to convert everything into an AppImage. It is ment to be used in github actions.
-
-Files 1, 2, 3 and 4 come from my fork of https://github.com/Kron4ek/Conty
-
-Files 1, 2 and 3 are a mod of the original ones to made them smaller and with only what its needed to made Steam work.
-
-To learn more about "Conty", to download more complete builds or to learn more on how to create your own, visit the official repository of the project:
-
-https://github.com/Kron4ek/Conty
---------------
+Run the `steam-runimage.sh` if you want to the build the AppImage locally on your system.
 
 ---------------------------------
-
-## Known issues
-
-### ◆ Very slow first startup for Nvidia users
-At the first start, if necessary, the drivers for your video card will be downloaded, via Conty (see screenshot above). This may take several seconds or even minutes. This behaviour will only be noticed if when you first start it, you launch Steam from the terminal instead of using the launcher.
-
----------------------------------
-
-## Credits
-
-- Conty https://github.com/Kron4ek/Conty
-
-------------------------------------------------------------------------
 
 ## Install and update it with ease
 

--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -104,7 +104,7 @@ rm -rfv ./AppDir/sharun/bin/chisel \
 
 VERSION="$(cat ~/version)"
 export ARCH="$(uname -m)"
-UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*squashfs-$ARCH.AppImage.zsync"
 
 # make appimage with type2-runtime
 # remove this if libappimage ever adopts support for dwarfs
@@ -117,6 +117,7 @@ chmod +x ./appimagetool
 	-n -u "$UPINFO" "$PWD"/AppDir "$PWD"/Steam-"$VERSION"-anylinux.squashfs-"$ARCH".AppImage
 
 # make appimage with uruntime
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*dwarfs-$ARCH.AppImage.zsync"
 URUNTIME=$(wget --retry-connrefused --tries=30 \
 	https://api.github.com/repos/VHSgunzo/uruntime/releases -O - \
 	| sed 's/[()",{} ]/\n/g' | grep -oi "https.*appimage.*dwarfs.*$ARCH$" | head -1)

--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -103,7 +103,7 @@ rm -rfv ./AppDir/sharun/bin/chisel \
 	./AppDir/rootfs/usr/share/icons/AdwaitaLegacy
 
 VERSION="$(cat ~/version)"
-ARCH="$(uname -m)"
+export ARCH="$(uname -m)"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 
 # make appimage with type2-runtime

--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -e
+
+# An example of steam packaging in a RunImage container
+
+if [ ! -x 'runimage' ]; then
+	echo '== download base RunImage'
+	curl -o runimage -L "https://github.com/VHSgunzo/runimage/releases/download/continuous/runimage-$(uname -m)"
+	chmod +x runimage
+fi
+
+run_install() {
+	set -e
+
+	INSTALL_PKGS=(
+		steam egl-wayland vulkan-radeon lib32-vulkan-radeon vulkan-tools
+		vulkan-intel lib32-vulkan-intel vulkan-nouveau lib32-vulkan-nouveau
+		vulkan-swrast lib32-vulkan-swrast lib32-libpipewire libpipewire pipewire
+		lib32-libpipewire libpulse lib32-libpulse vkd3d lib32-vkd3d wget
+		vulkan-mesa-layers lib32-vulkan-mesa-layers freetype2 lib32-freetype2 fuse2
+		yad mangohud lib32-mangohud gamescope gamemode zenity-gtk3 steam-screensaver-fix
+	)
+
+	echo '== checking for updates'
+	rim-update
+
+	echo '== install packages'
+	pac --needed --noconfirm -S "${INSTALL_PKGS[@]}"
+
+	echo '== install glibc with patches for Easy Anti-Cheat (optionally)'
+	yes|pac -S glibc-eac lib32-glibc-eac
+
+	echo '== install debloated llvm for space saving (optionally)'
+	LLVM=$(wget --retry-connrefused --tries=30 https://api.github.com/repos/Samueru-sama/llvm-libs-debloated/releases -O - \
+		| sed 's/[()",{} ]/\n/g' | grep -oi "https.*minimal.pkg.tar.zst$" | head -1)
+	wget --retry-connrefused --tries=30 "$LLVM" -O ./llvm-libs.pkg.tar.zst
+	pac -U --noconfirm ./llvm-libs.pkg.tar.zst
+	rm -f ./llvm-libs.pkg.tar.zst
+
+	echo '== shrink (optionally)'
+	pac -Rsndd --noconfirm wget gocryptfs adobe-source-code-pro-fonts jq \
+		gnupg webkit2gtk-4.1 perl vulkan-tools
+	rim-shrink --all
+	pac -Rsndd --noconfirm binutils
+
+
+	pac -Qi | awk -F': ' '/Name/ {name=$2}
+	/Installed Size/ {size=$2}
+	name && size {print name, size; name=size=""}' \
+		| column -t | grep MiB | sort -nk 2
+
+	VERSION=$(pacman -Q steam | awk 'NR==1 {print $2; exit}')
+	echo "$VERSION" > ~/version
+	cp /usr/share/icons/hicolor/256x256/apps/steam.png ~/
+	cp /usr/share/applications/steam.desktop ~/
+
+	echo '== create RunImage config for app (optionally)'
+	cat <<- 'EOF' > "$RUNDIR/config/Run.rcfg"
+	RIM_CMPRS_LVL="${RIM_CMPRS_LVL:=22}"
+	RIM_CMPRS_BSIZE="${RIM_CMPRS_BSIZE:=24}"
+
+	RIM_SYS_NVLIBS="${RIM_SYS_NVLIBS:=1}"
+
+	RIM_SHARE_ICONS="${RIM_SHARE_ICONS:=1}"
+	RIM_SHARE_FONTS="${RIM_SHARE_FONTS:=1}"
+	RIM_SHARE_THEMES="${RIM_SHARE_THEMES:=1}"
+	RIM_AUTORUN=steam-screensaver-fix-runtime
+	EOF
+
+	echo '== Build new DwarFS runimage with zstd 22 lvl and 24 block size'
+	rim-build -s steam.RunImage
+}
+export -f run_install
+
+##########################
+
+# enable OverlayFS mode, disable Nvidia driver check and run install steps
+RIM_OVERFS_MODE=1 RIM_NO_NVIDIA_CHECK=1 ./runimage bash -c run_install
+./steam.RunImage --runtime-extract
+rm -f ./steam.RunImage
+
+mv ./RunDir ./AppDir
+mv ./AppDir/Run ./AppDir/AppRun
+
+mv ~/steam.desktop ./AppDir
+mv ~/steam.png     ./AppDir
+sed -i '30i\StartupWMClass=steam' ./AppDir/steam.desktop
+
+# debloat
+rm -rfv ./AppDir/sharun/bin/chisel \
+	./AppDir/rootfs/usr/lib*/libgo.so* \
+	./AppDir/rootfs/usr/lib*/libgphobos.so* \
+	./AppDir/rootfs/usr/lib*/libgfortran.so* \
+	./AppDir/rootfs/usr/bin/rsvg-convert \
+	./AppDir/rootfs/usr/bin/rav1e \
+	./AppDir/rootfs/usr/bin/rsvg-convert \
+	./AppDir/rootfs/usr/*/*pacman* \
+	./AppDir/rootfs/usr/share/gir-1.0 \
+	./AppDir/rootfs/var/lib/pacman \
+	./AppDir/rootfs/etc/pacman* \
+	./AppDir/rootfs/usr/share/licenses \
+	./AppDir/rootfs/usr/share/terminfo \
+	./AppDir/rootfs/usr/share/icons/AdwaitaLegacy
+
+VERSION="$(cat ~/version)"
+ARCH="$(uname -m)"
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
+
+# make appimage with type2-runtime
+# remove this if libappimage ever adopts support for dwarfs
+APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+wget --retry-connrefused --tries=30 "$APPIMAGETOOL" -O ./appimagetool
+chmod +x ./appimagetool
+./appimagetool --comp zstd \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	--mksquashfs-opt -b --mksquashfs-opt 1M \
+	-n -u "$UPINFO" "$PWD"/AppDir "$PWD"/Steam-"$VERSION"-anylinux.squashfs-"$ARCH".AppImage
+
+# make appimage with uruntime
+URUNTIME=$(wget --retry-connrefused --tries=30 \
+	https://api.github.com/repos/VHSgunzo/uruntime/releases -O - \
+	| sed 's/[()",{} ]/\n/g' | grep -oi "https.*appimage.*dwarfs.*$ARCH$" | head -1)
+
+wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime
+chmod +x ./uruntime
+
+# Add udpate info to runtime
+echo "Adding update information \"$UPINFO\" to runtime..."
+printf "$UPINFO" > data.upd_info
+
+llvm-objcopy --update-section=.upd_info=data.upd_info \
+	--set-section-flags=.upd_info=noload,readonly ./uruntime
+printf 'AI\x02' | dd of=./uruntime bs=1 count=3 seek=8 conv=notrunc
+
+echo "Generating AppImage..."
+./uruntime --appimage-mkdwarfs -f \
+	--set-owner 0 --set-group 0 \
+	--no-history --no-create-timestamp \
+	--compression zstd:level=22 -S24 -B16 \
+	--header uruntime \
+	-i ./AppDir -o Steam-"$VERSION"-anylinux.dwarfs-"$ARCH".AppImage
+
+zsyncmake *dwarfs*.AppImage -u *dwarfs*.AppImage
+echo "All Done!"


### PR DESCRIPTION
Two appimages get produced now, one uses the `type2-runtime` and is 324 MiB. This is so that people that like to use the appimage thumbnailers and want the steam appimage to display its thumbnail will get it. 

The other appimage uses the dwarfs uruntime and is 271 MiB. 

Before we were putting `conty.sh` as dwarfs inside the squashfs appimage, this made it small and be compatible with the appimage thumbnailers, however this was a total waste of ram as well since we had dwarfs inside squashfs. 

