### PR TITLE
update debloated llvm url

### DIFF
--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -31,8 +31,7 @@ run_install() {
 	yes|pac -S glibc-eac lib32-glibc-eac
 
 	echo '== install debloated llvm for space saving (optionally)'
-	LLVM=$(wget --retry-connrefused --tries=30 https://api.github.com/repos/Samueru-sama/llvm-libs-debloated/releases -O - \
-		| sed 's/[()",{} ]/\n/g' | grep -oi "https.*minimal.pkg.tar.zst$" | head -1)
+	LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
 	wget --retry-connrefused --tries=30 "$LLVM" -O ./llvm-libs.pkg.tar.zst
 	pac -U --noconfirm ./llvm-libs.pkg.tar.zst
 	rm -f ./llvm-libs.pkg.tar.zst


### PR DESCRIPTION
Since now I have aarch64 builds the names were changed. 

**Do not trigger a manual work** During testing I discovered that the Steam package had a massive change (you will see the size of the appimage increases slightly). 

I did some basic tests and didn't notice anything broke from the changes of the new steam, but better wait for the scheduled release instead just in case. 