### PR TITLE
increase dwarfs blocksize even more

### DIFF
--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -132,7 +132,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B32 \
+	--compression zstd:level=22 -S25 -B8 \
 	--header uruntime \
 	-i ./AppDir -o Steam-"$VERSION"-anylinux.dwarfs-"$ARCH".AppImage
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/427a081c-27c1-4bce-afaa-28724b0f4793)

For some reason `-B` needs to be 8 in this case 🤔

`-B32` is bad, `-B16` is horrible 🤣 but no `-B` is also bad 