### PR TITLE
allow steam running as root, use `opus-nano`, remove `vulkan-swrast`

### DIFF
--- a/latest-release.txt
+++ b/latest-release.txt
@@ -1,2 +1,2 @@
-https://github.com/ivan-hc/Steam-appimage/releases/download/1.0.0.82-2/Steam-1.0.0.82-2-anylinux.dwarfs-x86_64.AppImage
-https://github.com/ivan-hc/Steam-appimage/releases/download/1.0.0.82-2/Steam-1.0.0.82-2-anylinux.squashfs-x86_64.AppImage
+https://github.com/Samueru-sama/Steam-appimage/releases/download/1.0.0.82-2/Steam-1.0.0.82-2-anylinux.dwarfs-x86_64.AppImage
+https://github.com/Samueru-sama/Steam-appimage/releases/download/1.0.0.82-2/Steam-1.0.0.82-2-anylinux.squashfs-x86_64.AppImage

--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -30,11 +30,13 @@ run_install() {
 	echo '== install glibc with patches for Easy Anti-Cheat (optionally)'
 	yes|pac -S glibc-eac lib32-glibc-eac
 
-	echo '== install debloated llvm for space saving (optionally)'
+	echo '== install debloated packages for space saving (optionally)'
 	LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
+	OPUS="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/opus-nano-x86_64.pkg.tar.zst"
 	wget --retry-connrefused --tries=30 "$LLVM" -O ./llvm-libs.pkg.tar.zst
-	pac -U --noconfirm ./llvm-libs.pkg.tar.zst
-	rm -f ./llvm-libs.pkg.tar.zst
+	wget --retry-connrefused --tries=30 "$OPUS" -O ./opus-nano.pkg.tar.zst
+	pac -U --noconfirm ./*.pkg.tar.zst
+	rm -f ./*.pkg.tar.zst
 
 	echo '== shrink (optionally)'
 	pac -Rsndd --noconfirm wget gocryptfs jq \
@@ -55,6 +57,9 @@ run_install() {
 
 	# Use host xdg-open
 	ln -sf /var/host/bin/xdg-open /usr/bin/xdg-open
+
+	# allow steam to run as root
+	sed -i 's|"$(id -u)" == "0"|"$(id -u)" == "69"|' /usr/lib/steam/bin_steam.sh
 
 	echo '== create RunImage config for app (optionally)'
 	cat <<- 'EOF' > "$RUNDIR/config/Run.rcfg"

--- a/steam-runimage.sh
+++ b/steam-runimage.sh
@@ -15,7 +15,7 @@ run_install() {
 	INSTALL_PKGS=(
 		steam egl-wayland vulkan-radeon lib32-vulkan-radeon vulkan-tools
 		vulkan-intel lib32-vulkan-intel vulkan-nouveau lib32-vulkan-nouveau
-		vulkan-swrast lib32-vulkan-swrast lib32-libpipewire libpipewire pipewire
+		lib32-libpipewire libpipewire pipewire
 		lib32-libpipewire libpulse lib32-libpulse vkd3d lib32-vkd3d wget
 		vulkan-mesa-layers lib32-vulkan-mesa-layers freetype2 lib32-freetype2 fuse2
 		yad mangohud lib32-mangohud gamescope gamemode zenity-gtk3 steam-screensaver-fix


### PR DESCRIPTION
There is no point in adding `vulkan-swrast`, any game will just be too slow with it, and people just get confused like it has happened before that they say that games are running too slow when it defaults to using that. 

running steam as root is a fix for https://github.com/pkgforge-dev/Anylinux-AppImages/issues/16